### PR TITLE
PiN/PiS

### DIFF
--- a/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
+++ b/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -153,7 +153,7 @@
        "(80372, 183593, 107033)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -197,7 +197,8 @@
     "acF_Syn = acF.compress(~miss_bool, axis=0)\n",
     "piFN = np.sum(allel.mean_pairwise_difference(acF_Non, fill=0))\n",
     "piFS = np.sum(allel.mean_pairwise_difference(acF_Syn, fill=0))\n",
-    "print(f'995F PiN/PiS = {piFN/piFS}')"
+    "F = piFN/piFS\n",
+    "print(f'995F PiN/PiS = {F}')"
    ]
   },
   {
@@ -218,7 +219,8 @@
     "acS_Syn = acS.compress(~miss_bool, axis=0)\n",
     "piSN = np.sum(allel.mean_pairwise_difference(acS_Non, fill=0))\n",
     "piSS = np.sum(allel.mean_pairwise_difference(acS_Syn, fill=0))\n",
-    "print(f'995S PiN/PiS = {piSN/piSS}')"
+    "S = piSN/piSS\n",
+    "print(f'995S PiN/PiS = {S}')"
    ]
   },
   {
@@ -239,8 +241,56 @@
     "acw_Syn = acw.compress(~miss_bool, axis=0)\n",
     "piwN = np.sum(allel.mean_pairwise_difference(acw_Non, fill=0))\n",
     "piwS = np.sum(allel.mean_pairwise_difference(acw_Syn, fill=0))\n",
-    "print(f'wt PiN/PiS = {piwN/piwS}')"
+    "wt = piwN/piwS\n",
+    "print(f'wt PiN/PiS = {wt}')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20.03831671434109"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "F/wt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.49890000406139456"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "S/wt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
+++ b/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Purifying selection - is this reduced on 995F haplotypes? \n",
     "## calculate PiN/PiS for 995F, 995S and wt haplotypes\n",
     "- If we do this per haplotype and take mean, we can get CIs"
    ]
@@ -50,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -69,7 +70,7 @@
        "0 0 0 0 0 ... 0 0 0 0 0"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -87,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -132,7 +133,7 @@
        "0 0 0 0 0 ... 0 0 0 0 0"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -143,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +153,7 @@
        "(80372, 183593, 107033)"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -168,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,72 +191,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PiN/PiS = 0.06363847066110961\n"
+      "995F PiN/PiS = 0.06363847066110961\n"
      ]
     }
    ],
    "source": [
     "acF_Non = acF.compress(miss_bool, axis=0)\n",
     "acF_Syn = acF.compress(~miss_bool, axis=0)\n",
-    "piFN = allel.sequence_diversity(pos_vgsc_N, acF_Non)\n",
-    "piFS = allel.sequence_diversity(pos_vgsc_S, acF_Syn)\n",
-    "print(f'PiN/PiS = {piFN/piFS}')"
+    "piFN = allel.sequence_diversity(pos_vgsc_Non, acF_Non)\n",
+    "piFS = allel.sequence_diversity(pos_vgsc_Syn, acF_Syn)\n",
+    "print(f'995F PiN/PiS = {piFN/piFS}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PiN/PiS = 0.0015844261633296837\n"
+      "995S PiN/PiS = 0.0015844261633296837\n"
      ]
     }
    ],
    "source": [
     "acS_Non = acS.compress(miss_bool, axis=0)\n",
     "acS_Syn = acS.compress(~miss_bool, axis=0)\n",
-    "piSN = allel.sequence_diversity(pos_vgsc_N, acS_Non)\n",
-    "piSS = allel.sequence_diversity(pos_vgsc_S, acS_Syn)\n",
-    "print(f'PiN/PiS = {piSN/piSS}')"
+    "piSN = allel.sequence_diversity(pos_vgsc_Non, acS_Non)\n",
+    "piSS = allel.sequence_diversity(pos_vgsc_Syn, acS_Syn)\n",
+    "print(f'995S PiN/PiS = {piSN/piSS}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PiN/PiS = 0.0031758391469860654\n"
+      "wt PiN/PiS = 0.0031758391469860654\n"
      ]
     }
    ],
    "source": [
     "acw_Non = acw.compress(miss_bool, axis=0)\n",
     "acw_Syn = acw.compress(~miss_bool, axis=0)\n",
-    "piwN = allel.sequence_diversity(pos_vgsc_N, acw_Non)\n",
-    "piwS = allel.sequence_diversity(pos_vgsc_S, acw_Syn)\n",
-    "print(f'PiN/PiS = {piwN/piwS}')"
+    "piwN = allel.sequence_diversity(pos_vgsc_Non, acw_Non)\n",
+    "piwS = allel.sequence_diversity(pos_vgsc_Syn, acw_Syn)\n",
+    "print(f'wt PiN/PiS = {piwN/piwS}')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# what about dn/ds"
+    "# what about dn/ds?"
    ]
   },
   {

--- a/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
+++ b/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +133,7 @@
        "0 0 0 0 0 ... 0 0 0 0 0"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -153,7 +153,7 @@
        "(80372, 183593, 107033)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,97 +181,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#getting weird allel pi results, there is a note in the docs- possibly due to problems working out how many positions it should use\n",
-    "#try chopping ac arrays to N and S first, so that is all it has to work with."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "995F PiN/PiS = 0.06363847066110961\n"
+      "995F PiN/PiS = 0.06359678721098909\n"
      ]
     }
    ],
    "source": [
     "acF_Non = acF.compress(miss_bool, axis=0)\n",
     "acF_Syn = acF.compress(~miss_bool, axis=0)\n",
-    "piFN = allel.sequence_diversity(pos_vgsc_Non, acF_Non)\n",
-    "piFS = allel.sequence_diversity(pos_vgsc_Syn, acF_Syn)\n",
+    "piFN = np.sum(allel.mean_pairwise_difference(acF_Non, fill=0))\n",
+    "piFS = np.sum(allel.mean_pairwise_difference(acF_Syn, fill=0))\n",
     "print(f'995F PiN/PiS = {piFN/piFS}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "995S PiN/PiS = 0.0015844261633296837\n"
+      "995S PiN/PiS = 0.0015833883579226286\n"
      ]
     }
    ],
    "source": [
     "acS_Non = acS.compress(miss_bool, axis=0)\n",
     "acS_Syn = acS.compress(~miss_bool, axis=0)\n",
-    "piSN = allel.sequence_diversity(pos_vgsc_Non, acS_Non)\n",
-    "piSS = allel.sequence_diversity(pos_vgsc_Syn, acS_Syn)\n",
+    "piSN = np.sum(allel.mean_pairwise_difference(acS_Non, fill=0))\n",
+    "piSS = np.sum(allel.mean_pairwise_difference(acS_Syn, fill=0))\n",
     "print(f'995S PiN/PiS = {piSN/piSS}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "wt PiN/PiS = 0.0031758391469860654\n"
+      "wt PiN/PiS = 0.003173758959776992\n"
      ]
     }
    ],
    "source": [
     "acw_Non = acw.compress(miss_bool, axis=0)\n",
     "acw_Syn = acw.compress(~miss_bool, axis=0)\n",
-    "piwN = allel.sequence_diversity(pos_vgsc_Non, acw_Non)\n",
-    "piwS = allel.sequence_diversity(pos_vgsc_Syn, acw_Syn)\n",
+    "piwN = np.sum(allel.mean_pairwise_difference(acw_Non, fill=0))\n",
+    "piwS = np.sum(allel.mean_pairwise_difference(acw_Syn, fill=0))\n",
     "print(f'wt PiN/PiS = {piwN/piwS}')"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# what about dn/ds?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
+++ b/notebooks/statistics_Phase_2_vgsc_PiN_PiS.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## calculate PiN/PiS for 995F, 995S and wt haplotypes\n",
+    "- If we do this per haplotype and take mean, we can get CIs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       ".container {\n",
+       "    width: 100%;\n",
+       "}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%run setup.ipynb\n",
+    "import hapclust"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data\n",
+    "callset_haps = np.load('../data/haps_phase2.npz')\n",
+    "haps = allel.HaplotypeArray(callset_haps['haplotypes'])\n",
+    "pos = allel.SortedIndex(callset_haps['POS'])\n",
+    "ann = callset_haps['ANN']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;HaplotypeArray shape=(2092, 2284) dtype=int8&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">...</th><th style=\"text-align: center\">2279</th><th style=\"text-align: center\">2280</th><th style=\"text-align: center\">2281</th><th style=\"text-align: center\">2282</th><th style=\"text-align: center\">2283</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"12\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2089</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2090</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2091</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<HaplotypeArray shape=(2092, 2284) dtype=int8>\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "...\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# chop into gene\n",
+    "start = 2358158\n",
+    "stop = 2431617\n",
+    "loc_vgsc = pos.locate_range(start, stop)\n",
+    "h_vgsc = haps[loc_vgsc]\n",
+    "pos_vgsc = pos[loc_vgsc]\n",
+    "ann_vgsc = ann['Annotation'][loc_vgsc]\n",
+    "h_vgsc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#chop into F, S and wt haplotypes\n",
+    "pos_995S = 2422651\n",
+    "pos_995F = 2422652\n",
+    "loc_995S = h_vgsc[pos_vgsc.locate_key(pos_995S)] == 1\n",
+    "loc_995F = h_vgsc[pos_vgsc.locate_key(pos_995F)] == 1\n",
+    "loc_res = loc_995F + loc_995S\n",
+    "loc_wt = ~loc_res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_vgsc_995F = h_vgsc.compress(loc_995F, axis=1)\n",
+    "h_vgsc_995S = h_vgsc.compress(loc_995S, axis=1)\n",
+    "h_vgsc_wt = h_vgsc.compress(loc_wt, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;HaplotypeArray shape=(2092, 1131) dtype=int8&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">...</th><th style=\"text-align: center\">1126</th><th style=\"text-align: center\">1127</th><th style=\"text-align: center\">1128</th><th style=\"text-align: center\">1129</th><th style=\"text-align: center\">1130</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"12\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2089</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2090</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2091</th><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td><td style=\"text-align: center\">0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<HaplotypeArray shape=(2092, 1131) dtype=int8>\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "...\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0\n",
+       "0 0 0 0 0 ... 0 0 0 0 0"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h_vgsc_995F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(80372, 183593, 107033)"
+      ]
+     },
+     "execution_count": 127,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#count alleles\n",
+    "acS = h_vgsc_995S.count_alleles()\n",
+    "acF = h_vgsc_995F.count_alleles()\n",
+    "acw = h_vgsc_wt.count_alleles()\n",
+    "#quick look at first ALT allele\n",
+    "sum(acS[:,1]), sum(acF[:,1]), sum(acw[:,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#get N and S positions\n",
+    "miss_bool = np.asarray([v  == b'missense_variant' for v in ann_vgsc])\n",
+    "pos_vgsc_Non = pos_vgsc.compress(miss_bool)\n",
+    "pos_vgsc_Syn = pos_vgsc.compress(~miss_bool)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#getting weird allel pi results, there is a note in the docs- possibly due to problems working out how many positions it should use\n",
+    "#try chopping ac arrays to N and S first, so that is all it has to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PiN/PiS = 0.06363847066110961\n"
+     ]
+    }
+   ],
+   "source": [
+    "acF_Non = acF.compress(miss_bool, axis=0)\n",
+    "acF_Syn = acF.compress(~miss_bool, axis=0)\n",
+    "piFN = allel.sequence_diversity(pos_vgsc_N, acF_Non)\n",
+    "piFS = allel.sequence_diversity(pos_vgsc_S, acF_Syn)\n",
+    "print(f'PiN/PiS = {piFN/piFS}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PiN/PiS = 0.0015844261633296837\n"
+     ]
+    }
+   ],
+   "source": [
+    "acS_Non = acS.compress(miss_bool, axis=0)\n",
+    "acS_Syn = acS.compress(~miss_bool, axis=0)\n",
+    "piSN = allel.sequence_diversity(pos_vgsc_N, acS_Non)\n",
+    "piSS = allel.sequence_diversity(pos_vgsc_S, acS_Syn)\n",
+    "print(f'PiN/PiS = {piSN/piSS}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PiN/PiS = 0.0031758391469860654\n"
+     ]
+    }
+   ],
+   "source": [
+    "acw_Non = acw.compress(miss_bool, axis=0)\n",
+    "acw_Syn = acw.compress(~miss_bool, axis=0)\n",
+    "piwN = allel.sequence_diversity(pos_vgsc_N, acw_Non)\n",
+    "piwS = allel.sequence_diversity(pos_vgsc_S, acw_Syn)\n",
+    "print(f'PiN/PiS = {piwN/piwS}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# what about dn/ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have recalculated PiN/PiS for haplotypes containing 995F, 995S and wt. 

These values look very different from those in the phase 1 manuscript but I can't find any code for this analysis @alimanfoo, do you remember if you calculated these? Here F haplotypes have PiN/PiS 20 times that of wt, whereas S is half of wt.

I have calculated these Pi values over all haplotypes in each group at a time, therefore I don't have CIs. If we think these are necessary, I can calculate each sample separately to build the distribution.

